### PR TITLE
Update Feature/c-so-integration - Step 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,8 @@ This section has moved here: https://facebook.github.io/create-react-app/docs/de
 ### `npm run build` fails to minify
 
 This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify
+
+## Integrations
+The supported method is via C-style header SO libraries. See https://medium.com/learning-the-go-programming-language/calling-go-functions-from-other-languages-4c7d8bcc69bf for details. Note that only CircleCI is building the header files.
+
+As of now, the pod configuration is adjusted in case there is incoming function call from integrated applications. This implementation is not aimed to push changes, but 'pull' instead.

--- a/integration/Golang/README.md
+++ b/integration/Golang/README.md
@@ -1,0 +1,3 @@
+# Introduction
+
+This folder contains C/C** header fields and Shareable Objects to enable integration with other projects via API and ABI.

--- a/integration/Java/README.md
+++ b/integration/Java/README.md
@@ -1,0 +1,3 @@
+# Introduction
+
+This folder contains C/C** header fields and Shareable Objects to enable integration with other projects via API and ABI.

--- a/integration/Python/README.md
+++ b/integration/Python/README.md
@@ -1,0 +1,3 @@
+# Introduction
+
+This folder contains C/C** header fiels nad Shareable Objects to enable integration with other projects via API and ABI.

--- a/integration/Python/README.md
+++ b/integration/Python/README.md
@@ -1,3 +1,3 @@
 # Introduction
 
-This folder contains C/C** header fiels nad Shareable Objects to enable integration with other projects via API and ABI.
+This folder contains C/C** header fields and Shareable Objects to enable integration with other projects via API and ABI.


### PR DESCRIPTION
This change:
 - Depends on #14 to enable Jenkins-Groovy-JNI (C/Cpp) loader implementation
 - Implements React->React Native->Java->JNI (C/Cpp) integration for Cloud Dashboard reaction on manually registered or automatically registered apps per Pro account presence (this branch is separating FE side from backend / Native Code side ); See https://stackoverflow.com/questions/23931827/how-to-call-a-c-method-from-javascript